### PR TITLE
Fix packages/gitignore, bump version 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /Cargo.lock
+.vscode/

--- a/crates/steam-client/Cargo.toml
+++ b/crates/steam-client/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 regex = "1"
 lazy_static = "1"
 bitvec = "0.17"
-enum_dispatch = "0.2"
+enum_dispatch = "0.3.5"
 
 # Futures related
 async-trait = "0.1"

--- a/crates/steam-language-gen/Cargo.toml
+++ b/crates/steam-language-gen/Cargo.toml
@@ -36,3 +36,4 @@ serde = { version = "1", features = ["derive"] }
 serde_repr = "0.1"
 
 steam-language-gen-derive = { path = "../steam-language-gen-derive", version = "0.1.0" }
+steam-protobuf = { path = "../steam-protobuf", version = "0.1.0" }

--- a/crates/steam-language-gen/src/generated/headers.rs
+++ b/crates/steam-language-gen/src/generated/headers.rs
@@ -1,10 +1,9 @@
 use derive_new::new;
 use serde::{Deserialize, Serialize};
 
-use crate::generated::enums::EMsg;
-use crate::{DeserializableBytes, MessageHeader, MessageHeaderExt, SerializableBytes};
+use crate::{generated::enums::EMsg, DeserializableBytes, MessageHeader, MessageHeaderExt, SerializableBytes};
 
-// use steam_protobuf::steam::steammessages_base::CMsgProtoBufHeader;
+use steam_protobuf::steam::steammessages_base::CMsgProtoBufHeader;
 
 // add protobuf
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -32,7 +31,6 @@ pub struct StandardMessageHeader {
     #[new(value = "std::u64::MAX")]
     pub source_job_id: u64,
 }
-
 
 #[derive(new, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, MsgHeader)]
 pub struct ExtendedMessageHeader {


### PR DESCRIPTION
The purpose of this PR is to fix a bunch of errors that get caused by a project being left out of steam-lang-gen, which should be used. Additionally, bumping the steam-lang-gen enum dispatch to fix an error caused by using a private module. Finally, editing the .gitignore to ignore files Visual Studio Code configuration files.