### PR TITLE
Update dependencies, and fix test errors

### DIFF
--- a/crates/steam-auth/Cargo.toml
+++ b/crates/steam-auth/Cargo.toml
@@ -41,7 +41,7 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2" # For testing
 thiserror = "1.0.20"
-tokio = { version = "0.2", features = ["rt-core", "macros", "time"] }
+tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros", "time"] }
 uuid = { version = "0.8.1", features = ["v4"] }
 
 strum = "0.19.5"
@@ -65,5 +65,5 @@ path = "../steam-language-gen"
 path = "../steamid-parser"
 
 [dependencies.reqwest]
-version = "0.10"
+version = "0.11"
 features = ["json", "cookies", "gzip"]

--- a/crates/steam-auth/src/client.rs
+++ b/crates/steam-auth/src/client.rs
@@ -166,7 +166,7 @@ impl SteamAuthenticator {
     pub async fn finalize_authenticator(&self, mafile: &MobileAuthFile, sms_code: &str) -> Result<(), AuthError> {
         // The delay is that Steam need some seconds to catch up with the new phone number associated.
         let account_has_phone_now: bool = check_sms(&self.client, sms_code)
-            .map_ok(|_| tokio::time::delay_for(Duration::from_secs(STEAM_ADD_PHONE_CATCHUP_SECS)))
+            .map_ok(|_| tokio::time::sleep(Duration::from_secs(STEAM_ADD_PHONE_CATCHUP_SECS)))
             .and_then(|_| account_has_phone(&self.client))
             .await?;
 
@@ -200,7 +200,7 @@ impl SteamAuthenticator {
         // Add the phone number to user account
         // The delay is that Steam need some seconds to catch up.
         let response = add_phone_to_account(&self.client, phone_number).await?;
-        tokio::time::delay_for(Duration::from_secs(STEAM_ADD_PHONE_CATCHUP_SECS)).await;
+        tokio::time::sleep(Duration::from_secs(STEAM_ADD_PHONE_CATCHUP_SECS)).await;
 
         Ok(response)
     }

--- a/crates/steam-auth/src/lib.rs
+++ b/crates/steam-auth/src/lib.rs
@@ -69,7 +69,7 @@ const MOBILE_REFERER: &str = concatcp!(
 /// Ideally all fields should be populated before authenticator operations are made.
 ///
 /// A simple implementation that has everything required to work properly:
-/// ```
+/// ```norun
 /// use steam_auth::User;
 ///
 /// User::build()

--- a/crates/steam-auth/src/web_handler/authenticator/mod.rs
+++ b/crates/steam-auth/src/web_handler/authenticator/mod.rs
@@ -156,7 +156,7 @@ pub(crate) async fn finalize_authenticator(
 
         // Steam want more codes, delay a bit and send all again.
         if response.want_more {
-            tokio::time::delay_for(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             tries += 1;
             continue;
         }

--- a/crates/steam-auth/src/web_handler/login.rs
+++ b/crates/steam-auth/src/web_handler/login.rs
@@ -99,7 +99,7 @@ pub(crate) async fn login_website<'a, LC: Into<Option<LoginCaptcha<'a>>>>(
         .await?;
 
     // wait for steam to catch up
-    time::delay_for(Duration::from_millis(STEAM_DELAY_MS)).await;
+    time::sleep(Duration::from_millis(STEAM_DELAY_MS)).await;
 
     // rsa handling
     let response = rsa_response.json::<RSAResponse>().await.unwrap();

--- a/crates/steam-client/Cargo.toml
+++ b/crates/steam-client/Cargo.toml
@@ -36,7 +36,7 @@ serde_repr = "^0"
 thiserror = "^1.0"
 
 # futures
-tokio = { version = "^1.1", features = ["net", "rt", "macros"] }
+tokio = { version = "^1.1", features = ["net", "rt-multi-thread", "macros"] }
 tokio-util = "^0.6"
 tokio-tungstenite = { version = "^0.13", optional = true }
 tokio-compat-02 = "0.2.0"

--- a/crates/steam-client/src/content_manager.rs
+++ b/crates/steam-client/src/content_manager.rs
@@ -10,7 +10,7 @@ pub async fn dump_tcp_servers() -> Result<Vec<String>> {
     let cm_list: GetCMListResponseBase = API_CLIENT
         .get()
         .ISteamDirectory()
-        .GetCMList(Some(25), None)
+        .GetCMList(25, None)
         .execute_with_response()
         .compat()
         .await?;

--- a/crates/steam-totp/Cargo.toml
+++ b/crates/steam-totp/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.3.4"
 crypto-mac = { version = "0.7.0", features = ["std"] }
 hex = "0.4.2"
 hmac = "0.7.1"
-reqwest = { version = "^0.10", features = ["json"] }
+reqwest = { version = "^0.11", features = ["json"] }
 serde = { version = "^1", features = ["derive"] }
 sha-1 = "0.8.2"
 url = "2"

--- a/crates/steam-trading/Cargo.toml
+++ b/crates/steam-trading/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "^1"
 serde_repr = "0.1.6"
 serde_with = { version = "^1.4", features = ["json"] }
 thiserror = "1"
-tokio = { version = "^0.2", features = ["rt-core", "macros", "time"] }
+tokio = { version = "^1.0.0", features = ["rt-multi-thread", "macros", "time"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2" # For testing

--- a/crates/steam-trading/src/lib.rs
+++ b/crates/steam-trading/src/lib.rs
@@ -218,7 +218,7 @@ impl<'a> SteamTradeManager<'a> {
             .for_each(|x| {
                 deny_offers_fut.push(
                     self.deny_offer(x)
-                        .map_ok(|_| tokio::time::delay_for(Duration::from_millis(STANDARD_DELAY))),
+                        .map_ok(|_| tokio::time::sleep(Duration::from_millis(STANDARD_DELAY))),
                 );
             });
 
@@ -241,7 +241,7 @@ impl<'a> SteamTradeManager<'a> {
     pub async fn create_offer_and_confirm(&self, tradeoffer: TradeOffer) -> Result<i64, TradeError> {
         let tradeoffer_id = self.create_offer(tradeoffer).await?;
 
-        tokio::time::delay_for(Duration::from_millis(STANDARD_DELAY)).await;
+        tokio::time::sleep(Duration::from_millis(STANDARD_DELAY)).await;
 
         let confirmations: Option<Confirmations> = self
             .authenticator

--- a/crates/steam-web-api/Cargo.toml
+++ b/crates/steam-web-api/Cargo.toml
@@ -20,7 +20,7 @@ trading = ["serde_repr", "serde_with"]
 [dependencies]
 cfg-if = "^1.0"
 paste = "~1.0.1"
-reqwest = { version = "^0.10", features = ["json"] }
+reqwest = { version = "^0.11", features = ["json"] }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
 thiserror = "^1.0"
@@ -42,5 +42,5 @@ version = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1"
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "1.0.0", features = ["full"] }
 compile-fail = { git = "https://github.com/rylev/compile-fail" }


### PR DESCRIPTION
In this PR, I've gone ahead and updated both tokio and reqwest to the latest versions, as to support the current tokio runtime. Additionally I've fixed some of the old functions that only worker with that version of tokio, and added `norun` to an example that used an invalid file.