### PR TITLE
Fix cargo doc

### DIFF
--- a/crates/steam-client/Cargo.toml
+++ b/crates/steam-client/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "^1.0"
 
 # futures
 tokio = { version = "^1.1", features = ["net", "rt", "macros"] }
-tokio-util = "^0.6"
+tokio-util = { version = "^0.6", features = ["codec"] }
 tokio-tungstenite = { version = "^0.13", optional = true }
 tokio-compat-02 = "0.2.0"
 

--- a/crates/steam-client/src/connection/encryption.rs
+++ b/crates/steam-client/src/connection/encryption.rs
@@ -4,7 +4,7 @@ use steam_language_gen::generated::enums::EMsg;
 use steam_language_gen::generated::messages::{
     MsgChannelEncryptRequest, MsgChannelEncryptResponse, MsgChannelEncryptResult,
 };
-use steam_language_gen::{MessageHeader, SerializableBytes};
+use steam_language_gen::{HasJobId, SerializableBytes};
 
 use crate::connection::{BytesTx, EncryptionState};
 use crate::errors::PacketError;
@@ -39,7 +39,7 @@ pub(crate) fn handle_encryption_negotiation(
 
     Ok(())
 }
-
+#[allow(unaligned_references)]
 fn handle_encrypt_result(message: PacketMessage) -> anyhow::Result<()> {
     let incoming_message: ClientMessage<MsgChannelEncryptResult> = ClientMessage::from_packet_message(message);
     println!("{:?}", incoming_message.body.result);

--- a/crates/steam-client/src/connection/encryption.rs
+++ b/crates/steam-client/src/connection/encryption.rs
@@ -39,7 +39,7 @@ pub(crate) fn handle_encryption_negotiation(
 
     Ok(())
 }
-#[allow(unaligned_references)]
+
 fn handle_encrypt_result(message: PacketMessage) -> anyhow::Result<()> {
     let incoming_message: ClientMessage<MsgChannelEncryptResult> = ClientMessage::from_packet_message(message);
     println!("{:?}", incoming_message.body.result);

--- a/crates/steam-client/src/messages/message.rs
+++ b/crates/steam-client/src/messages/message.rs
@@ -14,7 +14,7 @@ use steam_language_gen::generated::enums::EMsg;
 use steam_language_gen::generated::headers::{ExtendedMessageHeader, MessageHeaders, StandardMessageHeader};
 use steam_language_gen::generated::messages::HasEMsg;
 use steam_language_gen::{DeserializableBytes, MessageBodyExt, MessageHeaderWrapper, SerializableBytes};
-use steam_language_gen::{MessageHeader, MessageHeaderExt};
+use steam_language_gen::{HasJobId, MessageHeaderExt};
 use steam_protobuf::steam::steammessages_base::CMsgProtoBufHeader;
 use steam_protobuf::Message;
 

--- a/crates/steam-client/src/messages/packet.rs
+++ b/crates/steam-client/src/messages/packet.rs
@@ -4,7 +4,7 @@ use steam_language_gen::{
         enums::EMsg,
         headers::{ExtendedMessageHeader, StandardMessageHeader},
     },
-    DeserializableBytes, MessageHeader, MessageHeaderExt, MessageHeaderWrapper, SerializableBytes,
+    DeserializableBytes, HasJobId, MessageHeaderExt, MessageHeaderWrapper, SerializableBytes,
 };
 use steam_protobuf::{steam::steammessages_base::CMsgProtoBufHeader, Message};
 


### PR DESCRIPTION
-MessageHeader has been renamed to HasJobId

-tokio-util crate feature codec is needed to be enabled
```
error[E0432]: unresolved import `tokio_util::codec`
  --> crates/steam-client/src/connection/mod.rs:23:17
```

-Allowed unaligned_references, but ideally this should be fixed
https://github.com/rust-lang/rust/issues/82523