### PR TITLE
feat!: Auth is now typed with SteamAuthenticator<Authenticated> with proper methods;

### DIFF
--- a/crates/steam-mobile/src/errors.rs
+++ b/crates/steam-mobile/src/errors.rs
@@ -32,8 +32,6 @@ pub enum ApiKeyError {
     AccessDenied,
     #[error("Key not yet registered.")]
     NotRegistered,
-    #[error("A method requiring a cached key was used, but this account API KEY could not be cached.")]
-    NotCached,
     #[error(transparent)]
     InternalError(#[from] InternalError),
 }
@@ -43,8 +41,6 @@ pub enum ApiKeyError {
 pub enum LoginError {
     #[error("Message returned: `{0}`")]
     GeneralFailure(String),
-    #[error("Need a SteamID associated with user.")]
-    NeedSteamID,
     #[error("Parental unlock error `{0}`")]
     ParentalUnlock(String),
     #[error("Steam Guard Mobile is not enabled. Email codes are not supported.")]
@@ -54,10 +50,8 @@ pub enum LoginError {
     #[error("Requires a captcha code. If a previous attempt was made, the captcha was probably incorrect. \
     Captcha GUID: `{0}`", .captcha_guid)]
     CaptchaRequired { captcha_guid: String },
-
     #[error(transparent)]
     InternalError(#[from] InternalError),
-
     #[error(transparent)]
     TotpError(#[from] steam_totp::error::TotpError),
 }
@@ -70,15 +64,12 @@ pub enum LinkerError {
     GeneralFailure(String),
     #[error("An authenticator is already linked to this account. Please remove the old one before adding a new one.")]
     AuthenticatorPresent,
-
     #[error("The SMS code you entered is incorrect.")]
     BadSMSCode,
     #[error("We were unable to generate the correct codes. Perhaps something changed?")]
     UnableToGenerateCorrectCodes,
-
     #[error(transparent)]
     InternalError(#[from] InternalError),
-
     #[error(transparent)]
     TotpError(#[from] steam_totp::error::TotpError),
 }

--- a/crates/steam-mobile/src/web_handler/login/login_types.rs
+++ b/crates/steam-mobile/src/web_handler/login/login_types.rs
@@ -1,6 +1,7 @@
 //! Types used to login into Steam via web
 
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct PollAuthSessionStatusRequest {

--- a/crates/steam-mobile/src/web_handler/steam_guard_linker/types.rs
+++ b/crates/steam-mobile/src/web_handler/steam_guard_linker/types.rs
@@ -1,5 +1,7 @@
-use serde::{Deserialize, Serialize};
-use strum_macros::{Display, IntoStaticStr};
+use serde::Deserialize;
+use serde::Serialize;
+use strum_macros::Display;
+use strum_macros::IntoStaticStr;
 
 use crate::utils::generate_canonical_device_id;
 use crate::web_handler::steam_guard_linker::RemoveAuthenticatorScheme;
@@ -17,13 +19,13 @@ pub enum PhoneAjaxOperation {
     HasPhone,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Display, IntoStaticStr)]
-/// This is finite state machine.
+/// FSM (finite-state-machine)
 /// We get the future state as a response of the current state.
 ///
 ///
-/// Example: If the current operation 'retry_email_verification' succeds, we will receive
-/// 'get_sms_code' on the state field of the response, indicating that it will be the next operation.
+/// Example: If the current operation `retry_email_verification` succeeds, we will receive
+/// `get_sms_code` on the state field of the response, indicating that it will be the next operation.
+#[derive(Copy, Clone, Debug, Serialize, Display, IntoStaticStr)]
 pub enum StorePhoneAjaxOp {
     #[strum(serialize = "retry_email_verification")]
     RetryEmailVerification,
@@ -224,6 +226,29 @@ struct RemoveAuthenticatorResponse {
     pub revocation_attempts_remaining: i64,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct QueryStatusResponseBase {
+    #[serde(rename = "response")]
+    pub inner: QueryStatusResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryStatusResponse {
+    pub state: i64,
+    pub inactivation_reason: i64,
+    pub authenticator_type: i64,
+    pub authenticator_allowed: bool,
+    pub steamguard_scheme: i64,
+    pub token_gid: String,
+    pub email_validated: bool,
+    pub device_identifier: String,
+    /// Epoch
+    pub time_created: i64,
+    pub revocation_attempts_remaining: i64,
+    pub classified_agent: String,
+    pub version: i64,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AddAuthenticatorResponseBase {
     #[serde(rename = "response")]
@@ -281,30 +306,6 @@ pub struct FinalizeAddAuthenticatorErrorBase {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct FinalizeAddAuthenticatorErrorResponse {
     pub status: i64,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct StoreFinalizeAuthenticatorRequest {
-    input: String,
-    #[serde(rename = "sessionID")]
-    sessionid: String,
-    confirmed: String,
-    checkfortos: String,
-    bisediting: String,
-    token: String,
-}
-
-impl Default for StoreFinalizeAuthenticatorRequest {
-    fn default() -> Self {
-        Self {
-            input: "".to_string(),
-            sessionid: "".to_string(),
-            confirmed: "1".to_string(),
-            checkfortos: "1".to_string(),
-            bisediting: "0".to_string(),
-            token: "0".to_string(),
-        }
-    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]


### PR DESCRIPTION
* access_token is now working correctly for QueryStatus, for example, but still need to adapt all linker-related methods;

BREAKING CHANGES:
* Removed weird utility functions around Confirmations;
* Only method available on SteamAuthenticator<Unauthenticated> is login mostly;